### PR TITLE
Update Shortcut-FE kernel 6.12 patch

### DIFF
--- a/PATCH/kernel/sfe/953-net-patch-linux-kernel-to-support-shortcut-fe.patch
+++ b/PATCH/kernel/sfe/953-net-patch-linux-kernel-to-support-shortcut-fe.patch
@@ -1,8 +1,8 @@
 --- a/include/linux/if_bridge.h
 +++ b/include/linux/if_bridge.h
-@@ -72,6 +72,9 @@ void brioctl_set(int (*hook)(struct net
- int br_ioctl_call(struct net *net, struct net_bridge *br, unsigned int cmd,
- 		  struct ifreq *ifr, void __user *uarg);
+@@ -70,6 +70,9 @@ void brioctl_set(int (*hook)(struct net
+ 			     void __user *uarg));
+ int br_ioctl_call(struct net *net, unsigned int cmd, void __user *uarg);
  
 +extern void br_dev_update_stats(struct net_device *dev,
 +				struct rtnl_link_stats64 *nlstats);
@@ -12,16 +12,16 @@
  			       struct list_head *br_ip_list);
 --- a/include/linux/skbuff.h
 +++ b/include/linux/skbuff.h
-@@ -1011,6 +1011,9 @@ struct sk_buff {
+@@ -1012,6 +1012,9 @@ struct sk_buff {
  	__u8			csum_not_inet:1;
  #endif
  	__u8			unreadable:1;
 +#ifdef CONFIG_SHORTCUT_FE
 +	__u8			fast_forwarded:1;
 +#endif
+ 	__u8			tc_depth:2;
  #if defined(CONFIG_NET_SCHED) || defined(CONFIG_NET_XGRESS)
  	__u16			tc_index;	/* traffic control index */
- #endif
 --- a/include/net/netfilter/nf_conntrack_ecache.h
 +++ b/include/net/netfilter/nf_conntrack_ecache.h
 @@ -68,6 +68,8 @@ struct nf_ct_event_notifier {
@@ -47,7 +47,7 @@
  	select DIMLIB
 --- a/net/bridge/br_if.c
 +++ b/net/bridge/br_if.c
-@@ -764,6 +764,28 @@ void br_port_flags_change(struct net_bri
+@@ -765,6 +765,28 @@ void br_port_flags_change(struct net_bri
  		br_recalculate_neigh_suppress_enabled(br);
  }
  
@@ -78,7 +78,7 @@
  	struct net_bridge_port *p;
 --- a/net/core/dev.c
 +++ b/net/core/dev.c
-@@ -3654,9 +3654,17 @@ static int xmit_one(struct sk_buff *skb,
+@@ -3684,9 +3684,17 @@ static int xmit_one(struct sk_buff *skb,
  {
  	unsigned int len;
  	int rc;
@@ -97,7 +97,7 @@
  
  #ifdef CONFIG_ETHERNET_PACKET_MANGLE
  	if (dev->eth_mangle_tx && !(skb = dev->eth_mangle_tx(dev, skb)))
-@@ -5505,6 +5513,11 @@ void netdev_rx_handler_unregister(struct
+@@ -5548,6 +5556,11 @@ void netdev_rx_handler_unregister(struct
  }
  EXPORT_SYMBOL_GPL(netdev_rx_handler_unregister);
  
@@ -109,7 +109,7 @@
  /*
   * Limit the use of PFMEMALLOC reserves to those protocols that implement
   * the special handling of PFMEMALLOC skbs.
-@@ -5553,6 +5566,10 @@ static int __netif_receive_skb_core(stru
+@@ -5596,6 +5609,10 @@ static int __netif_receive_skb_core(stru
  	int ret = NET_RX_DROP;
  	__be16 type;
  
@@ -120,7 +120,7 @@
  	net_timestamp_check(!READ_ONCE(net_hotdata.tstamp_prequeue), skb);
  
  	trace_netif_receive_skb(skb);
-@@ -5591,6 +5608,15 @@ another_round:
+@@ -5634,6 +5651,15 @@ another_round:
  			goto out;
  	}
  


### PR DESCRIPTION
## Summary

Update the kernel 6.12 Shortcut-FE 953 patch from the current coolsnowwolf/lede source.

## Why

The previous patch no longer applies cleanly on newer 6.12 kernel headers such as 6.12.94 because `include/linux/skbuff.h` gained `tc_depth`, so the old hunk fails while preparing `toolchain/kernel-headers`.

## Validation

- Confirmed the updated `include/linux/skbuff.h` hunk applies with `patch --dry-run` against Linux 6.12.94.
- Confirmed the updated patch contains the `tc_depth` context used by the newer kernel header layout.
